### PR TITLE
Remove redundant `/` in west.yml

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -4,7 +4,7 @@ manifest:
 
   remotes:
     - name: github
-      url-base: https://github.com/
+      url-base: https://github.com
 
   projects:
     - name: nrf


### PR DESCRIPTION
West adds a forward slash between url-base and repo-path. An additional one after `github.com` leads to an error, so remove it.

```
=== updating nrf (nrf):
--- nrf: initializing
Initialized empty Git repository in /home/robin/sevenlab/sewerin/workspace/nrf/.git/
--- nrf: fetching, need revision v3.0.0-rc1
fatal: remote error:
 /nrfconnect/sdk-nrf is not a valid repository name
Visit https://support.github.com/ for help
FATAL ERROR: command exited with status 128: fetch -f --tags -- https://github.com//nrfconnect/sdk-nrf v3.0.0-rc1
```