### PR TITLE
Timeseries telemetry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run super-linter
-        uses: super-linter/super-linter/slim@v7.1.0
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           DEFAULT_BRANCH: main
           RUN_LOCAL: "true"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(CONFIG_THINGSBOARD)
     zephyr_library_sources(
         src/coap_client.c
         src/thingsboard.c
+        src/timeseries_json.c
         ${CMAKE_CURRENT_BINARY_DIR}/generated/thingsboard_attr_serde.c
         ${CMAKE_CURRENT_BINARY_DIR}/generated/thingsboard_telemetry_serde.c
     )

--- a/include/thingsboard.h
+++ b/include/thingsboard.h
@@ -45,6 +45,14 @@ struct thingsboard_cbs {
 };
 
 /**
+ * One timeseries element. Used to attach a timestamp to a `thingsboard_telemetry` object.
+ */
+struct thingsboard_timeseries {
+	time_t ts;
+	struct thingsboard_telemetry values;
+};
+
+/**
  * Return the current time in seconds.
  * Time is initially retreived from Thingsboard, given that your
  * rule chain supports it.
@@ -74,6 +82,15 @@ int thingsboard_send_telemetry_buf(const void *payload, size_t sz);
  * See https://thingsboard.io/docs/user-guide/telemetry/ for details.
  */
 int thingsboard_send_telemetry(const struct thingsboard_telemetry *telemetry);
+
+/**
+ * Serialize and send timeseries, which is multiple telemetry object with
+ * timestamps attached.
+ * Be aware that Thingsboard expects timestamps with millisecond-precision,
+ * as provided by `thingsboard_time_msec()`.
+ * See https://thingsboard.io/docs/user-guide/telemetry/ for details.
+ */
+int thingsboard_send_timeseries(const struct thingsboard_timeseries *ts, size_t ts_count);
 
 struct tb_fw_id {
 	/** Title of your firmware, e.g. <project>-prod. This

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -9,8 +9,9 @@
 #include <thingsboard_attr_serde.h>
 
 #include "coap_client.h"
-#include "tb_fota.h"
 #include "provision.h"
+#include "tb_fota.h"
+#include "timeseries.h"
 
 LOG_MODULE_REGISTER(thingsboard_client, CONFIG_THINGSBOARD_LOG_LEVEL);
 
@@ -188,6 +189,16 @@ static void client_request_time(struct k_work *work)
 int thingsboard_send_telemetry(const struct thingsboard_telemetry *telemetry)
 {
 	int err = thingsboard_telemetry_to_buf(telemetry, serde_buffer, sizeof(serde_buffer));
+	if (err < 0) {
+		return err;
+	}
+
+	return thingsboard_send_telemetry_buf(serde_buffer, strlen(serde_buffer));
+}
+
+int thingsboard_send_timeseries(const struct thingsboard_timeseries *ts, size_t ts_count)
+{
+	int err = thingsboard_timeseries_to_buf(ts, ts_count, serde_buffer, sizeof(serde_buffer));
 	if (err < 0) {
 		return err;
 	}

--- a/src/timeseries.h
+++ b/src/timeseries.h
@@ -1,0 +1,9 @@
+#ifndef TB_TIMESERIES_H
+#define TB_TIMESERIES_H
+
+#include <thingsboard.h>
+
+int thingsboard_timeseries_to_buf(const struct thingsboard_timeseries *ts, size_t ts_count,
+				  char *buffer, size_t len);
+
+#endif /* TB_TIMESERIES_H */


### PR DESCRIPTION
Add a new concept of timeseries data. Thingsboard allows to attach a timestamp to telemetry objects, as well as sending multiple of those in an array.

To send timeseries telemetry, `thingsboard_send_timeseries()` can be used.

Superlinter needed some update, to get a recent clang-format version.