### PR TITLE
Split too large timeseries

### DIFF
--- a/include/thingsboard.h
+++ b/include/thingsboard.h
@@ -86,9 +86,15 @@ int thingsboard_send_telemetry(const struct thingsboard_telemetry *telemetry);
 /**
  * Serialize and send timeseries, which is multiple telemetry object with
  * timestamps attached.
+ *
+ * Data might be sent in multiple messages.
+ *
  * Be aware that Thingsboard expects timestamps with millisecond-precision,
  * as provided by `thingsboard_time_msec()`.
+ *
  * See https://thingsboard.io/docs/user-guide/telemetry/ for details.
+ *
+ * Returns negative on error, 0 on success
  */
 int thingsboard_send_timeseries(const struct thingsboard_timeseries *ts, size_t ts_count);
 

--- a/src/timeseries.h
+++ b/src/timeseries.h
@@ -3,7 +3,16 @@
 
 #include <thingsboard.h>
 
-int thingsboard_timeseries_to_buf(const struct thingsboard_timeseries *ts, size_t ts_count,
-				  char *buffer, size_t len);
+/**
+ * Encodes multiple `struct thingsboard_timeseries` into an json array.
+ *
+ * Note: only encodes as much `struct thingsboard_timeseries` as fit into the
+ * given `len`.
+ *
+ * Returns negative values for error, positive values for the amount of
+ * `struct thingsboard_timeseries` which fitted into `buffer`.
+ */
+ssize_t thingsboard_timeseries_to_buf(const struct thingsboard_timeseries *ts, size_t ts_count,
+				      char *buffer, size_t len);
 
 #endif /* TB_TIMESERIES_H */


### PR DESCRIPTION
When a timeseries array is too large, split it into multiple messages.