### PR TITLE
thingsboard_messages_json: Remove trailing zero byte from message

### DIFF
--- a/src/thingsboard_messages_json.c
+++ b/src/thingsboard_messages_json.c
@@ -178,8 +178,7 @@ int thingsboard_timeseries_encode(const thingsboard_timeseries *ts, size_t *ts_c
 	buffer[pos++] = ']';
 	left--;
 
-	buffer[pos++] = 0;
-	left--;
+	buffer[pos] = 0;
 
 	*len = pos;
 	*ts_count = ts_encoded;


### PR DESCRIPTION
The timeseries message contained a trailing zero, which made Thingsboard to not accept the JSON object.