### PR TITLE
Suspending mechanism

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -151,6 +151,10 @@ config THINGSBOARD_TELEMETRY_ALWAYS_TIMESTAMP
     help
       When enabled, thingsboard always adds timestamp to telemetry data.
 
+config THINGSBOARD_CONNECT_ON_INIT
+    bool "Connect to Thingsboard init"
+    default y
+
 module = THINGSBOARD
 module-str = Thingsboard SDK
 source "subsys/logging/Kconfig.template.log_config"

--- a/Kconfig
+++ b/Kconfig
@@ -122,6 +122,28 @@ config THINGSBOARD_DTLS
       certificate, as well as the client certificate and key. Only certificate
       authentication is supported.
 
+choice THINGSBOARD_SOCKET_SUSPEND
+    bool "Socket suspend mechanism"
+    default THINGSBOARD_SOCKET_SUSPEND_NONE
+
+config THINGSBOARD_SOCKET_SUSPEND_NONE
+    bool "None"
+    help
+      Do nothing
+
+config THINGSBOARD_SOCKET_SUSPEND_DISCONNECT
+    bool "Disconnect"
+    help
+      Disconnect socket, create and connect a new one on resume
+
+config THINGSBOARD_SOCKET_SUSPEND_RAI
+    bool "RAI"
+    help
+      Set the socket option SO_RAI to RAI_NO_DATA. On resume SO_RAI is set
+      to RAI_ONGOING.
+
+endchoice # THINGSBOARD_SOCKET_SUSPEND
+
 config THINGSBOARD_TELEMETRY_ALWAYS_TIMESTAMP
     bool "Always send timestamp with telemetry"
     default y

--- a/include/thingsboard.h
+++ b/include/thingsboard.h
@@ -29,9 +29,19 @@ enum thingsboard_event {
 	THINGSBOARD_EVENT_ACTIVE,
 
 	/**
+	 * Thingsboard client has been suspended.
+	 */
+	THINGSBOARD_EVENT_SUSPENDED,
+
+	/**
 	 * A time update from thingsboard has been received.
 	 */
 	THINGSBOARD_EVENT_TIME_UPDATE,
+
+	/**
+	 * Thingsboard client has been disconnected.
+	 */
+	THINGSBOARD_EVENT_DISCONNECTED,
 };
 
 #ifdef CONFIG_THINGSBOARD_CONTENT_FORMAT_JSON
@@ -235,6 +245,44 @@ void thingsboard_lock(void);
  * Unlock Thingsboard SDKs internal lock.
  */
 void thingsboard_unlock(void);
+
+/**
+ * (Re-)Connect to Thingsboard.
+ *
+ * @retval -EINVAL Thingsboard client is in the wrong state or not initialized
+ * @retval -EALREAY Already connected to Thingsboard
+ * @retval -ENOTCONN Failed to connect to Thingsboard
+ * @retval 0 Reconnecting to Thingsboard
+ */
+int thingsboard_connect(void);
+
+/**
+ * Disconnect from Thingsboard.
+ *
+ * @retval -EINVAL Thingsboard client is in the wrong state or not initialized
+ * @retval -EALREAY Thingsboard client is not connected
+ * @retval 0 Success
+ */
+int thingsboard_disconnect(void);
+
+/**
+ * Suspend Thingsboard Client operation.
+ *
+ * This can be used, when the application e.g. enters a deep-sleep mode and
+ * does not want the Thingsboard client to communicate for a while.
+ *
+ * @retval -EINVAL Thingsboard client is in the wrong state or not initialized
+ * @retval 0 Success
+ */
+int thingsboard_suspend(void);
+
+/**
+ * Resume Thingsboard Client operation.
+ *
+ * @retval -EINVAL Thingsboard client is in the wrong state or not initialized
+ * @retval 0 Success
+ */
+int thingsboard_resume(void);
 
 /**
  * Get the current state of shared attributes.

--- a/src/provision.c
+++ b/src/provision.c
@@ -108,7 +108,9 @@ static void client_handle_prov_resp(int16_t result_code, size_t offset, const ui
 		prov_cb(access_token);
 	}
 out:
-	thingsboard_request_free(request);
+	if (last_block) {
+		thingsboard_request_free(request);
+	}
 
 	return;
 }

--- a/src/provision.c
+++ b/src/provision.c
@@ -135,7 +135,7 @@ static int make_provisioning_request(const char *device_name)
 		goto error;
 	}
 
-	request->coap_request = (struct coap_client_request){
+	struct coap_client_request coap_request = {
 		.payload = request->payload,
 		.len = strlen(request->payload),
 		.confirmable = true,
@@ -147,8 +147,8 @@ static int make_provisioning_request(const char *device_name)
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
-			      (struct sockaddr *)thingsboard_client.server_address,
-			      &request->coap_request, NULL);
+			      (struct sockaddr *)thingsboard_client.server_address, &coap_request,
+			      NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send provisioning request: %d", err);
 		err = -EFAULT;

--- a/src/tb_fota.c
+++ b/src/tb_fota.c
@@ -195,7 +195,7 @@ static int client_fw_request_image(void)
 
 	request->options[0] = coap_client_option_initial_block2();
 
-	request->coap_request = (struct coap_client_request){
+	struct coap_client_request coap_request = {
 		.confirmable = true,
 		.method = COAP_METHOD_GET,
 		.path = request->payload,
@@ -206,8 +206,8 @@ static int client_fw_request_image(void)
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
-			      (struct sockaddr *)thingsboard_client.server_address,
-			      &request->coap_request, NULL);
+			      (struct sockaddr *)thingsboard_client.server_address, &coap_request,
+			      NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to request next firmware chunk: %d", err);
 		thingsboard_request_free(request);

--- a/src/tb_fota.c
+++ b/src/tb_fota.c
@@ -153,7 +153,7 @@ out:
 	switch (state) {
 	case TB_FW_DOWNLOADING:
 		/* We are expecting more blocks */
-		return;
+		break;
 	case TB_FW_DOWNLOADED:
 		fw_apply();
 		break;
@@ -164,7 +164,9 @@ out:
 		break;
 	}
 
-	thingsboard_request_free(request);
+	if (last_block) {
+		thingsboard_request_free(request);
+	}
 }
 
 static int client_fw_request_image(void)

--- a/src/tb_internal.h
+++ b/src/tb_internal.h
@@ -59,7 +59,17 @@ struct thingsboard_request {
 	char payload[CONFIG_COAP_CLIENT_MESSAGE_SIZE];
 };
 
+enum thingsboard_state {
+	THINGSBOARD_STATE_INIT,
+	THINGSBOARD_STATE_CONNECTING,
+	THINGSBOARD_STATE_CONNECTED,
+	THINGSBOARD_STATE_SUSPENDED,
+	THINGSBOARD_STATE_DISCONNECTED,
+};
+
 struct thingsboard_client {
+	enum thingsboard_state state;
+
 	const struct thingsboard_configuration *config;
 
 	struct coap_client coap_client;
@@ -200,11 +210,47 @@ int thingsboard_socket_connect(const struct thingsboard_configuration *config,
 			       size_t *server_address_len);
 
 /**
+ * Suspend socket.
+ *
+ * Action is determined by the THINGSBOARD_SOCKET_SUSPEND Kconfig option.
+ *
+ * When setting THINGSBOARD_SOCKET_SUSPEND_NONE, will be defined as weak symbol.
+ *
+ * @param sock Pointer to current socket. Might be overwritten. Will be set to -1 when it has been
+ * closed.
+ *
+ * @return 0 in success, negative on error
+ */
+int thingsboard_socket_suspend(int *sock);
+
+/**
+ * Resume socket.
+ *
+ * Action is determined by the THINGSBOARD_SOCKET_SUSPEND Kconfig option.
+ *
+ * When setting THINGSBOARD_SOCKET_SUSPEND_NONE, will be defined as weak symbol.
+ *
+ * @param sock Pointer to current socket. Might be overwritten. Will be set to -1 when it has been
+ * closed.
+ *
+ * @return 0 in success, negative on error
+ */
+int thingsboard_socket_resume(int *sock);
+
+/**
  * Close socket.
  *
  * @param sock Socket to close
  */
 void thingsboard_socket_close(int sock);
+
+/**
+ * Check for Thingsboard being connected.
+ *
+ * @retval true when the Thingsboard client is initialized, connected and ready to do send requests.
+ * @retval false when the Thingsboard client should not try to send data.
+ */
+bool thingsboard_is_active(void);
 
 /**
  * Send event to application.
@@ -218,7 +264,30 @@ void thingsboard_event(enum thingsboard_event event);
  * Start time synchronization.
  */
 void thingsboard_start_time_sync(void);
+
+/**
+ * Stop time synchronization.
+ */
+void thingsboard_stop_time_sync(void);
+
 #endif /* CONFIG_THINGSBOARD_TIME */
+
+/**
+ * Subscribe(observe) attributes notification.
+ *
+ * Can only be done, when not already subscribed.
+ *
+ * @return 0 on success, negative on error
+ */
+int thingsboard_client_subscribe_attributes(void);
+
+/**
+ * Unsubscribe attributes notifications.
+ *
+ * @retval 0 success
+ * @retval -EALREADY not subscribed to attributes notification
+ */
+int thingsboard_client_unsubscribe_attributes(void);
 
 ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 				      thingsboard_attributes *current, void *buffer,

--- a/src/tb_internal.h
+++ b/src/tb_internal.h
@@ -52,7 +52,6 @@ typedef struct {
 #endif /* CONFIG_THINGSBOARD_CONTENT_FORMAT_JSON */
 
 struct thingsboard_request {
-	struct coap_client_request coap_request;
 	void (*rpc_cb)(const uint8_t *payload, size_t len);
 	struct coap_client_option options[1];
 	char path[CONFIG_THINGSBOARD_REQUEST_MAX_PATH_LENGTH];

--- a/src/tb_internal.h
+++ b/src/tb_internal.h
@@ -288,6 +288,20 @@ int thingsboard_client_subscribe_attributes(void);
  */
 int thingsboard_client_unsubscribe_attributes(void);
 
+/**
+ * Update `thingsboard_attributes` stuct. Attributes set in `changes` will be
+ * `current`. When using JSON encoding, `buffer` needs to be given as storage
+ * location for strings. The JSON code gen provides
+ * `struct thingsboard_attributes_buffer`, which holds buffers for each string
+ * entry in `thingsboard_attributes`.
+ *
+ * @param changes Changes/updates to be applied to `current`
+ * @param current Current state, to be updated
+ * @param buffer Buffer to store strings into. Only needed for JSON encoding
+ * @param buffer_len Size of `buffer`
+ *
+ * @return Amount of attributes which have been copied to `current` or negative on error
+ */
 ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 				      thingsboard_attributes *current, void *buffer,
 				      size_t buffer_len);

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -823,11 +823,13 @@ int thingsboard_init(const struct thingsboard_configuration *configuration)
 
 	thingsboard_client.state = THINGSBOARD_STATE_DISCONNECTED;
 
+#ifdef CONFIG_THINGSBOARD_CONNECT_ON_INIT
 	ret = thingsboard_connect();
 	if (ret < 0) {
 		LOG_ERR("Failed to connect to Thingsboard instance: %d", ret);
 		return -ENOTCONN;
 	}
+#endif /* CONFIG_THINGSBOARD_CONNECT_ON_INIT */
 
 	return 0;
 }

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -391,7 +391,8 @@ int thingsboard_client_subscribe_attributes(void)
 
 	thingsboard_client.attributes_observation->options[0].code = COAP_OPTION_OBSERVE;
 	thingsboard_client.attributes_observation->options[0].len = 0;
-	thingsboard_client.attributes_observation->coap_request = (struct coap_client_request){
+
+	struct coap_client_request coap_request = {
 		.confirmable = true,
 		.method = COAP_METHOD_GET,
 		.path = thingsboard_client.attributes_observation->path,
@@ -402,8 +403,8 @@ int thingsboard_client_subscribe_attributes(void)
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
-			      (struct sockaddr *)thingsboard_client.server_address,
-			      &thingsboard_client.attributes_observation->coap_request, NULL);
+			      (struct sockaddr *)thingsboard_client.server_address, &coap_request,
+			      NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send attributes observation: %d", err);
 		thingsboard_request_free(thingsboard_client.attributes_observation);
@@ -423,7 +424,8 @@ int thingsboard_client_unsubscribe_attributes(void)
 	}
 
 	coap_client_cancel_request(&thingsboard_client.coap_client,
-				   &thingsboard_client.attributes_observation->coap_request);
+				   &(struct coap_client_request){
+					   .user_data = thingsboard_client.attributes_observation});
 
 	return 0;
 }
@@ -584,7 +586,7 @@ int thingsboard_send_telemetry_request(struct thingsboard_request *request, size
 		return -EFAULT;
 	}
 
-	request->coap_request = (struct coap_client_request){
+	struct coap_client_request coap_request = {
 		.payload = request->payload,
 		.len = sz,
 		.confirmable = true,
@@ -596,8 +598,8 @@ int thingsboard_send_telemetry_request(struct thingsboard_request *request, size
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
-			      (struct sockaddr *)thingsboard_client.server_address,
-			      &request->coap_request, NULL);
+			      (struct sockaddr *)thingsboard_client.server_address, &coap_request,
+			      NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send telemetry: %d", err);
 		thingsboard_request_free(request);
@@ -666,7 +668,7 @@ int thingsboard_send_rpc_request(thingsboard_rpc_request *r,
 	}
 
 	request->rpc_cb = rpc_cb;
-	request->coap_request = (struct coap_client_request){
+	struct coap_client_request coap_request = {
 		.payload = request->payload,
 		.len = request_len,
 		.confirmable = true,
@@ -678,8 +680,8 @@ int thingsboard_send_rpc_request(thingsboard_rpc_request *r,
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
-			      (struct sockaddr *)thingsboard_client.server_address,
-			      &request->coap_request, NULL);
+			      (struct sockaddr *)thingsboard_client.server_address, &coap_request,
+			      NULL);
 	if (err < 0) {
 		LOG_ERR("Failed to send RPC request: %d", err);
 		thingsboard_request_free(request);

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -13,10 +13,13 @@ LOG_MODULE_REGISTER(thingsboard_client, CONFIG_THINGSBOARD_LOG_LEVEL);
 
 struct thingsboard_client thingsboard_client = {
 	.server_socket = -1,
+	.state = THINGSBOARD_STATE_INIT,
 };
 
 K_MEM_SLAB_DEFINE_STATIC(request_slab, sizeof(struct thingsboard_request),
 			 CONFIG_COAP_CLIENT_MAX_REQUESTS, 4);
+
+static void start_client(void);
 
 void thingsboard_lock(void)
 {
@@ -83,6 +86,207 @@ void thingsboard_request_free(struct thingsboard_request *request)
 	k_mem_slab_free(&request_slab, request);
 }
 
+bool thingsboard_is_active(void)
+{
+	return thingsboard_client.state == THINGSBOARD_STATE_CONNECTED;
+}
+
+static const char *thingsboard_state_to_a(enum thingsboard_state state)
+{
+	switch (state) {
+	case THINGSBOARD_STATE_INIT:
+		return "INIT";
+	case THINGSBOARD_STATE_CONNECTING:
+		return "CONNECTING";
+	case THINGSBOARD_STATE_CONNECTED:
+		return "CONNECTED";
+	case THINGSBOARD_STATE_SUSPENDED:
+		return "SUSPENDED";
+	case THINGSBOARD_STATE_DISCONNECTED:
+		return "DISCONNECTED";
+	}
+
+	return "UNKNOWN";
+}
+
+static void thingsboard_set_state(enum thingsboard_state new_state);
+
+static void thingsboard_handle_state_connecting(void)
+{
+	start_client();
+}
+
+static void thingsboard_handle_state_connected(void)
+{
+	thingsboard_event(THINGSBOARD_EVENT_ACTIVE);
+}
+
+static void thingsboard_handle_state_suspended(void)
+{
+	thingsboard_event(THINGSBOARD_EVENT_SUSPENDED);
+}
+
+static void thingsboard_handle_state_disconnected(void)
+{
+	thingsboard_event(THINGSBOARD_EVENT_DISCONNECTED);
+}
+
+static void thingsboard_set_state(enum thingsboard_state new_state)
+{
+	thingsboard_lock();
+
+	if (new_state == thingsboard_client.state) {
+		thingsboard_unlock();
+		return;
+	}
+
+	LOG_DBG("%s -> %s", thingsboard_state_to_a(thingsboard_client.state),
+		thingsboard_state_to_a(new_state));
+
+	thingsboard_client.state = new_state;
+
+	switch (new_state) {
+	case THINGSBOARD_STATE_INIT:
+		/* This is not expected to happen */
+		__ASSERT_NO_MSG(false);
+		break;
+	case THINGSBOARD_STATE_CONNECTING:
+		thingsboard_handle_state_connecting();
+		break;
+	case THINGSBOARD_STATE_CONNECTED:
+		thingsboard_handle_state_connected();
+		break;
+	case THINGSBOARD_STATE_SUSPENDED:
+		thingsboard_handle_state_suspended();
+		break;
+	case THINGSBOARD_STATE_DISCONNECTED:
+		thingsboard_handle_state_disconnected();
+		break;
+	}
+
+	thingsboard_unlock();
+}
+
+int thingsboard_connect(void)
+{
+	thingsboard_lock();
+
+	switch (thingsboard_client.state) {
+	case THINGSBOARD_STATE_CONNECTED:
+	case THINGSBOARD_STATE_SUSPENDED:
+		thingsboard_unlock();
+		return -EALREADY;
+	case THINGSBOARD_STATE_DISCONNECTED:
+		break;
+	default:
+		thingsboard_unlock();
+		return -EINVAL;
+	}
+
+	int ret = thingsboard_socket_connect(thingsboard_client.config,
+					     &thingsboard_client.server_address,
+					     &thingsboard_client.server_address_len);
+	if (ret < 0) {
+		LOG_ERR("Failed to connect socket: %d", ret);
+		thingsboard_set_state(THINGSBOARD_STATE_DISCONNECTED);
+		return -ENOTCONN;
+	}
+	thingsboard_client.server_socket = ret;
+
+	thingsboard_set_state(THINGSBOARD_STATE_CONNECTING);
+
+	thingsboard_unlock();
+
+	return 0;
+}
+
+int thingsboard_disconnect(void)
+{
+	thingsboard_lock();
+
+	switch (thingsboard_client.state) {
+	case THINGSBOARD_STATE_CONNECTED:
+	case THINGSBOARD_STATE_SUSPENDED:
+		break;
+	case THINGSBOARD_STATE_DISCONNECTED:
+		thingsboard_unlock();
+		return -EALREADY;
+	default:
+		thingsboard_unlock();
+		return -EINVAL;
+	}
+
+	int err = thingsboard_client_unsubscribe_attributes();
+	if (err == -EALREADY) {
+		LOG_DBG("Was not subscribed to attributes notification");
+	}
+
+#ifdef CONFIG_THINGSBOARD_TIME
+	thingsboard_stop_time_sync();
+#endif /* CONFIG_THINGSBOARD_TIME */
+
+	thingsboard_socket_close(thingsboard_client.server_socket);
+
+	thingsboard_set_state(THINGSBOARD_STATE_DISCONNECTED);
+
+	thingsboard_unlock();
+
+	return 0;
+}
+
+int thingsboard_suspend(void)
+{
+	thingsboard_lock();
+
+	if (thingsboard_client.state == THINGSBOARD_STATE_SUSPENDED) {
+		thingsboard_unlock();
+		return 0;
+	}
+
+	if (thingsboard_client.state != THINGSBOARD_STATE_CONNECTED) {
+		thingsboard_unlock();
+		return -EINVAL;
+	}
+
+	int err = thingsboard_socket_suspend(&thingsboard_client.server_socket);
+	if (err < 0) {
+		LOG_ERR("Failed to suspend socket: %d", err);
+	}
+
+	thingsboard_set_state(THINGSBOARD_STATE_SUSPENDED);
+
+	thingsboard_unlock();
+
+	return 0;
+}
+
+int thingsboard_resume(void)
+{
+	thingsboard_lock();
+
+	if (thingsboard_client.state == THINGSBOARD_STATE_CONNECTED) {
+		thingsboard_unlock();
+		return 0;
+	}
+
+	if (thingsboard_client.state != THINGSBOARD_STATE_SUSPENDED) {
+		thingsboard_unlock();
+		return -EINVAL;
+	}
+
+	int err = thingsboard_socket_resume(&thingsboard_client.server_socket);
+	if (err < 0) {
+		LOG_ERR("Failed to resume socket: %d", err);
+		return -EFAULT;
+	}
+
+	thingsboard_set_state(THINGSBOARD_STATE_CONNECTED);
+
+	thingsboard_unlock();
+
+	return 0;
+}
+
 static void coap_decode_response_code(uint8_t code, uint8_t *class, uint8_t *detail)
 {
 	*class = (code >> 5);
@@ -103,21 +307,32 @@ static void client_handle_attribute_notification(int16_t result_code, size_t off
 						 bool last_block, void *user_data)
 {
 	thingsboard_attributes attr = {0};
+	struct thingsboard_request *request = user_data;
 	int err;
+
+	thingsboard_lock();
+
+	if (result_code == -ECANCELED) {
+		LOG_DBG("Attributes subscription has been canceled");
+		goto out;
+	}
+
+	if (result_code < 0) {
+		LOG_ERR("Attributes notification failed: %d", result_code);
+		goto out;
+	}
 
 	if (!len) {
 		LOG_WRN("Received empty attributes");
-		return;
+		goto out;
 	}
 	LOG_HEXDUMP_DBG(payload, len, "Received attributes");
 
 	err = thingsboard_attributes_decode(payload, len, &attr);
 	if (err < 0) {
 		LOG_ERR("Parsing attributes failed");
-		return;
+		goto out;
 	}
-
-	thingsboard_lock();
 
 #ifdef CONFIG_THINGSBOARD_CONTENT_FORMAT_JSON
 	ssize_t ret =
@@ -145,10 +360,12 @@ static void client_handle_attribute_notification(int16_t result_code, size_t off
 		thingsboard_client.config->callbacks.on_attributes_write(&attr);
 	}
 
+out:
+
 	thingsboard_unlock();
 }
 
-static int client_subscribe_to_attributes(void)
+int thingsboard_client_subscribe_attributes(void)
 {
 	int err;
 
@@ -177,6 +394,7 @@ static int client_subscribe_to_attributes(void)
 		.options = thingsboard_client.attributes_observation->options,
 		.num_options = 1,
 		.cb = client_handle_attribute_notification,
+		.user_data = thingsboard_client.attributes_observation,
 	};
 
 	err = coap_client_req(&thingsboard_client.coap_client, thingsboard_client.server_socket,
@@ -194,15 +412,27 @@ static int client_subscribe_to_attributes(void)
 	return 0;
 }
 
+int thingsboard_client_unsubscribe_attributes(void)
+{
+	if (thingsboard_client.attributes_observation == NULL) {
+		return -EALREADY;
+	}
+
+	coap_client_cancel_request(&thingsboard_client.coap_client,
+				   &thingsboard_client.attributes_observation->coap_request);
+
+	return 0;
+}
+
 int thingsboard_send_telemetry_request(struct thingsboard_request *request, size_t sz);
 
 int thingsboard_send_telemetry(const thingsboard_telemetry *telemetry)
 {
-#ifndef CONFIG_THINGSBOARD_DTLS
-	if (!thingsboard_client.access_token) {
-		return -ENOENT;
+	__ASSERT_NO_MSG(telemetry);
+
+	if (!thingsboard_is_active()) {
+		return -EAGAIN;
 	}
-#endif /* CONFIG_THINGSBOARD_DTLS */
 
 #ifdef CONFIG_THINGSBOARD_TELEMETRY_ALWAYS_TIMESTAMP
 	thingsboard_timeseries timeseries = {
@@ -231,11 +461,9 @@ int thingsboard_send_telemetry(const thingsboard_telemetry *telemetry)
 
 int thingsboard_send_timeseries(const thingsboard_timeseries *ts, size_t ts_count)
 {
-#ifndef CONFIG_THINGSBOARD_DTLS
-	if (!thingsboard_client.access_token) {
-		return -ENOENT;
+	if (!thingsboard_is_active()) {
+		return -EAGAIN;
 	}
-#endif /* CONFIG_THINGSBOARD_DTLS */
 
 	int err;
 	struct thingsboard_request *requests[CONFIG_COAP_CLIENT_MAX_REQUESTS] = {NULL};
@@ -318,11 +546,12 @@ out:
 
 int thingsboard_send_telemetry_buf(const void *payload, size_t sz)
 {
-#ifndef CONFIG_THINGSBOARD_DTLS
-	if (!thingsboard_client.access_token) {
-		return -ENOENT;
+	__ASSERT_NO_MSG(payload);
+	__ASSERT_NO_MSG(sz > 0);
+
+	if (!thingsboard_is_active()) {
+		return -EAGAIN;
 	}
-#endif /* CONFIG_THINGSBOARD_DTLS */
 
 	if (sz > sizeof(((struct thingsboard_request){}).payload)) {
 		return -EINVAL;
@@ -459,8 +688,6 @@ void thingsboard_event(enum thingsboard_event event)
 	}
 }
 
-static void start_client(void);
-
 #ifdef CONFIG_THINGSBOARD_USE_PROVISIONING
 static void prov_callback(const char *token)
 {
@@ -484,6 +711,7 @@ static void start_client(void)
 						       prov_callback);
 		if (err < 0) {
 			LOG_ERR("Could not provision device: %d", err);
+			thingsboard_set_state(THINGSBOARD_STATE_DISCONNECTED);
 			return;
 		}
 
@@ -502,16 +730,19 @@ static void start_client(void)
 	}
 #endif
 
-	int err = client_subscribe_to_attributes();
+	int err = thingsboard_client_subscribe_attributes();
 	if (err < 0) {
 		LOG_ERR("Failed to observe attributes: %d", err);
+		thingsboard_socket_close(thingsboard_client.server_socket);
+		thingsboard_set_state(THINGSBOARD_STATE_DISCONNECTED);
+		return;
 	}
 
 #ifdef CONFIG_THINGSBOARD_TIME
 	thingsboard_start_time_sync();
 #endif /* CONFIG_THINGSBOARD_TIME */
 
-	thingsboard_event(THINGSBOARD_EVENT_ACTIVE);
+	thingsboard_set_state(THINGSBOARD_STATE_CONNECTED);
 }
 
 static bool string_is_set(const char *str)
@@ -527,6 +758,10 @@ const thingsboard_attributes *thingsboard_get_attributes(void)
 int thingsboard_init(const struct thingsboard_configuration *configuration)
 {
 	int ret;
+
+	if (thingsboard_client.state != THINGSBOARD_STATE_INIT) {
+		return -EALREADY;
+	}
 
 	if (thingsboard_client.server_socket >= 0) {
 		return -EALREADY;
@@ -570,22 +805,19 @@ int thingsboard_init(const struct thingsboard_configuration *configuration)
 
 	thingsboard_client.config = configuration;
 
-	ret = thingsboard_socket_connect(thingsboard_client.config,
-					 &thingsboard_client.server_address,
-					 &thingsboard_client.server_address_len);
-	if (ret < 0) {
-		LOG_ERR("Failed to connect socket: %d", ret);
-		return -ENETUNREACH;
-	}
-	thingsboard_client.server_socket = ret;
-
 	ret = coap_client_init(&thingsboard_client.coap_client, "Thingsboard Client");
 	if (ret != 0) {
 		LOG_ERR("Failed to initialize CoAP client (%d)", ret);
 		return ret;
 	}
 
-	start_client();
+	thingsboard_client.state = THINGSBOARD_STATE_DISCONNECTED;
+
+	ret = thingsboard_connect();
+	if (ret < 0) {
+		LOG_ERR("Failed to connect to Thingsboard instance: %d", ret);
+		return -ENOTCONN;
+	}
 
 	return 0;
 }

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -361,6 +361,10 @@ static void client_handle_attribute_notification(int16_t result_code, size_t off
 	}
 
 out:
+	if (last_block) {
+		thingsboard_client.attributes_observation = NULL;
+		thingsboard_request_free(request);
+	}
 
 	thingsboard_unlock();
 }
@@ -541,7 +545,9 @@ static void thingsboard_handle_response(int16_t result_code, size_t offset, cons
 	LOG_DBG("Request completed with code %s", code_str);
 
 out:
-	thingsboard_request_free(request);
+	if (last_block) {
+		thingsboard_request_free(request);
+	}
 }
 
 int thingsboard_send_telemetry_buf(const void *payload, size_t sz)
@@ -628,7 +634,9 @@ static void thingsboard_handle_rpc_response(int16_t result_code, size_t offset,
 	}
 
 out:
-	thingsboard_request_free(request);
+	if (last_block) {
+		thingsboard_request_free(request);
+	}
 }
 
 int thingsboard_send_rpc_request(thingsboard_rpc_request *r,


### PR DESCRIPTION
Allow explicit handling of connecting and disconnecting the Thingsboard Client.

This also adds a mechanism to "suspend" and "resume" the connection. This mechanism is quite flexible and can be configured to do nothing or a user specified action, disconnect and reconnect the socket and to set RAI options.