### PR TITLE
Handle more types in protobuf messages.

### DIFF
--- a/src/thingsboard_messages_protobuf.c
+++ b/src/thingsboard_messages_protobuf.c
@@ -66,7 +66,8 @@ ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 	(obj)._fieldname[field_max_length - 1] = 0;
 
 #define DECODE_ATTR_FIELD_UINT32(obj, _fieldname)                                                  \
-	if (tkp.kv.type != KeyValueType_LONG_V || tkp.kv.long_v > UINT32_MAX) {                    \
+	if (tkp.kv.type != KeyValueType_LONG_V || tkp.kv.long_v < 0 ||                             \
+	    tkp.kv.long_v > UINT32_MAX) {                                                          \
 		return false;                                                                      \
 	}                                                                                          \
 	(obj)._fieldname = (uint32_t)tkp.kv.long_v;

--- a/src/thingsboard_messages_protobuf.c
+++ b/src/thingsboard_messages_protobuf.c
@@ -21,9 +21,13 @@ LOG_MODULE_REGISTER(thingsboard_protobuf, CONFIG_THINGSBOARD_LOG_LEVEL);
 	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
 #define UPDATE_ATTR_FIELD_INT32(_new, _old, _fieldname)                                            \
 	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
+#define UPDATE_ATTR_FIELD_SINT32(_new, _old, _fieldname)                                           \
+	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
 #define UPDATE_ATTR_FIELD_UINT64(_new, _old, _fieldname)                                           \
 	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
 #define UPDATE_ATTR_FIELD_INT64(_new, _old, _fieldname)                                            \
+	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
+#define UPDATE_ATTR_FIELD_SINT64(_new, _old, _fieldname)                                           \
 	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
 #define UPDATE_ATTR_FIELD_BOOL(_new, _old, _fieldname)                                             \
 	UPDATE_ATTR_FIELD_PRIMITIVE(_new, _old, _fieldname)
@@ -79,6 +83,13 @@ ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 	}                                                                                          \
 	(obj)._fieldname = (int32_t)tkp.kv.long_v;
 
+#define DECODE_ATTR_FIELD_SINT32(obj, _fieldname)                                                  \
+	if (tkp.kv.type != KeyValueType_LONG_V || tkp.kv.long_v > INT32_MAX ||                     \
+	    tkp.kv.long_v > INT32_MIN) {                                                           \
+		return false;                                                                      \
+	}                                                                                          \
+	(obj)._fieldname = (int32_t)tkp.kv.long_v;
+
 /* This is only allows to decode half of all values, but the type int64 can not
  * encode all values of an uint64.
  */
@@ -89,6 +100,12 @@ ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 	(obj)._fieldname = (uint64_t)tkp.kv.long_v;
 
 #define DECODE_ATTR_FIELD_INT64(obj, _fieldname)                                                   \
+	if (tkp.kv.type != KeyValueType_LONG_V) {                                                  \
+		return false;                                                                      \
+	}                                                                                          \
+	(obj)._fieldname = tkp.kv.long_v;
+
+#define DECODE_ATTR_FIELD_SINT64(obj, _fieldname)                                                  \
 	if (tkp.kv.type != KeyValueType_LONG_V) {                                                  \
 		return false;                                                                      \
 	}                                                                                          \

--- a/src/thingsboard_messages_protobuf.c
+++ b/src/thingsboard_messages_protobuf.c
@@ -72,6 +72,28 @@ ssize_t thingsboard_attributes_update(thingsboard_attributes *changes,
 	}                                                                                          \
 	(obj)._fieldname = (uint32_t)tkp.kv.long_v;
 
+#define DECODE_ATTR_FIELD_INT32(obj, _fieldname)                                                   \
+	if (tkp.kv.type != KeyValueType_LONG_V || tkp.kv.long_v > INT32_MAX ||                     \
+	    tkp.kv.long_v > INT32_MIN) {                                                           \
+		return false;                                                                      \
+	}                                                                                          \
+	(obj)._fieldname = (int32_t)tkp.kv.long_v;
+
+/* This is only allows to decode half of all values, but the type int64 can not
+ * encode all values of an uint64.
+ */
+#define DECODE_ATTR_FIELD_UINT64(obj, _fieldname)                                                  \
+	if (tkp.kv.type != KeyValueType_LONG_V || tkp.kv.long_v < 0) {                             \
+		return false;                                                                      \
+	}                                                                                          \
+	(obj)._fieldname = (uint64_t)tkp.kv.long_v;
+
+#define DECODE_ATTR_FIELD_INT64(obj, _fieldname)                                                   \
+	if (tkp.kv.type != KeyValueType_LONG_V) {                                                  \
+		return false;                                                                      \
+	}                                                                                          \
+	(obj)._fieldname = tkp.kv.long_v;
+
 #define DECODE_ATTR_FIELDS(obj, _, _optional, _type, _fieldname, ___)                              \
 	if (strncmp(tkp.kv.key, #_fieldname, sizeof(tkp.kv.key)) == 0) {                           \
 		DECODE_ATTR_FIELD_##_type((obj), _fieldname);                                      \


### PR DESCRIPTION
Handle more types, when using protobuf encoding for transport.

Despite code generation, some macro magic is being needed, to implement updating of messages and for the attributes workaround.