### PR TITLE
thingsboard: allow communication in the connecting state

### DIFF
--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -88,7 +88,8 @@ void thingsboard_request_free(struct thingsboard_request *request)
 
 bool thingsboard_is_active(void)
 {
-	return thingsboard_client.state == THINGSBOARD_STATE_CONNECTED;
+	return thingsboard_client.state == THINGSBOARD_STATE_CONNECTED ||
+	       thingsboard_client.state == THINGSBOARD_STATE_CONNECTING;
 }
 
 static const char *thingsboard_state_to_a(enum thingsboard_state state)


### PR DESCRIPTION
During the `THINGSBOARD_STATE_CONNECTING` state, the socket already has been setup, but `thingsboard_is_active()` will return `false` and some communication, like the initial reporting of the FOTA state, is supressed. To fix that problem, communication must be allowed during the `THINGSBOARD_STATE_CONNECTING` state.

The naming is now a bit odd, as the "active" state of a device does not really correspond in a strict manner with the returned value of that function any more.