### PR TITLE
Fix two memory bugs

### DIFF
--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -53,12 +53,12 @@ int thingsboard_cat_path(const char *in[], char *out, size_t out_len)
 		if (left < in_len) {
 			return -ENOMEM;
 		}
-		memcpy(&out[pos], in[i], left);
+		memcpy(&out[pos], in[i], in_len);
 		pos += in_len;
 		left -= in_len;
 	}
 
-	if (pos > out_len) {
+	if (left < 1) {
 		return -ENOMEM;
 	}
 

--- a/src/thingsboard.c
+++ b/src/thingsboard.c
@@ -366,7 +366,8 @@ static void client_handle_attribute_notification(int16_t result_code, size_t off
 	}
 
 out:
-	if (last_block) {
+	if (last_block && result_code < 0) {
+		__ASSERT_NO_MSG(thingsboard_client.attributes_observation == request);
 		thingsboard_client.attributes_observation = NULL;
 		thingsboard_request_free(request);
 	}


### PR DESCRIPTION
After weird crashes of the Thingsboard client on network disconnect and re-connect, i searched for memory bugs causing this problem. I found two, where the second one actually cause the problem.